### PR TITLE
implementation of the Sysclient protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@
 # local sessions
 myapps_session*
 
+
+#### sysclient
+# local sysclient sessions
+sysclient_*.txt
+# static folder for sysclient
+devices/ 
+
 # vscode
 .vscode/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # go-myapps
 
-A golang client to connect to one or more myApps accounts of users at a innovaphone pbx via websocket.
+- A golang client to connect to one or more myApps accounts of users at a innovaphone pbx via websocket.
+
+- A implementation of the sysclient protocol. See README.md in the ./sysclient/ folder.
 
 ## Introduction
 

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,13 @@ go 1.19
 require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/stretchr/testify v1.8.1
+	gotest.tools v2.2.0+incompatible
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,12 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -17,3 +21,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/sysclient/README.md
+++ b/sysclient/README.md
@@ -1,0 +1,149 @@
+# Sysclient
+
+An implementation of the Sysclient protocol described at [Sysclient protocol](https://sdk.innovaphone.com/13r3/doc/protocol/sysclient.htm)
+
+- connects a Go client to the innovaphone Devices App as a sysclient like any other device.
+- can be used to provide a web interface with text or other functions.
+- or to record or check the configurations devices receive from the Devices app.
+- useful during the development of myApps apps when they have to have access to devices. Allows to use mock/dummy devices instead of having to maintain real ones.
+
+## Example usage of the libary
+
+``` go
+package main
+
+import (
+	"embed"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ricoschulte/go-myapps/sysclient"
+)
+
+
+// this is a local folder in your project 
+// the files and dirs in this directory are build into the go binary and
+// can be requested over a tunnel connection within the device app
+
+//go:embed devices/*
+var StaticDevicesFolderFS embed.FS
+
+func main() {
+	// define the properties of the device that connects to the devices app as sysclient
+	identity := sysclient.Identity{
+		Id:      "f19033480af9",
+		Product: "IP232",
+		Version: "13r2 dvl [13.4250/131286/1300]",
+		FwBuild: "134250",
+		BcBuild: "131286",
+		Major:   "13r2",
+		Fw:      "ip222.bin",
+		Bc:      "boot222.bin",
+		Mini:    false,
+        PbxActive: false,
+        Other: false,
+		Platform: sysclient.Platform{
+			Type: "PHONE",
+		},
+		EthIfs: []sysclient.EthIf{
+			{
+				If:   "ETH0",
+				Ipv4: "172.16.4.141",
+				Ipv6: "2002:91fd:9d07:0:290:33ff:fe46:af2",
+			},
+		},
+	}
+
+	sc, err_creating_sysclient := sysclient.NewSysclient(
+		// the identity from above
+		identity,
+
+		
+		// the Devices App URL to connect to
+        // ws[s]://<ip/host>[:<port>]/<domain></instance>/sysclients
+	    "wss://apps.company.com/company.com/devices/sysclients"
+
+		// a timeout duration for the websocket
+		time.Duration(2*time.Second),
+
+		// InsecureSkipVerify: if true, the verification of the TLS certificate is skipped.
+		// Do not use in production. You have been warned.
+		false,
+
+		// a SeveMux for requested HTTP request, see below
+		getServeMux(),
+
+		// filenames to store the password of the sysclient and a received and decoded admin password
+		"sysclient_password.txt",
+		"sysclient_administrativepassword.txt",
+	)
+
+	// when no error has happend while creating the client ...
+	if err_creating_sysclient != nil {
+		panic(err_creating_sysclient)
+	}
+	// ... start it.
+	sc.Connect()
+
+	select {} // keep the program running
+}
+
+// create a ServeMux for handling Tunnel Http Requests
+func getServerMux() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Serve a file for the /admin.xml path
+	mux.HandleFunc("/admin.xml", func(w http.ResponseWriter, r *http.Request) {
+		response_text := `<html><body>`
+		response_text += fmt.Sprintf(`page on %s`, r.URL.Path)
+		response_text += "</body></html>"
+
+		w.Header().Add("Content-Length", fmt.Sprint(len(response_text)))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response_text))
+	})
+
+	// Serve a file for the /CMD0/mod_cmd.xml endpoint the will receive configurations
+	mux.HandleFunc("/CMD0/mod_cmd.xml", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("---------------------------")
+		fmt.Println("received on", r.URL.Path)
+		fmt.Println("received headers", r.Header)
+		for key, value := range r.URL.Query() {
+			fmt.Println("received param", key, value)
+		}
+
+		response_text := `<html><body>`
+		response_text += fmt.Sprintf(`mod_cmd.xml page on %s`, r.URL.Path)
+		response_text += "</body></html>"
+
+		w.Header().Add("Content-Length", fmt.Sprint(len(response_text)))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response_text))
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			// catch not existing path with error log
+			response_text := fmt.Sprintf("Path %s not found", r.URL.Path)
+			fmt.Println("REQUEST 404", r.URL.Path)
+			w.Header().Add("Content-Length", fmt.Sprint(len(response_text)))
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(response_text))
+
+			return
+		}
+
+		response_text := `<html><body>`
+		response_text += fmt.Sprintf(`page on %s`, r.URL.Path)
+		response_text += "</body></html>"
+
+		w.Header().Add("Content-Length", fmt.Sprint(len(response_text)))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response_text))
+
+	})
+
+	return mux
+}
+```

--- a/sysclient/README.md
+++ b/sysclient/README.md
@@ -9,11 +9,14 @@ An implementation of the Sysclient protocol described at [Sysclient protocol](ht
 
 ## Example usage of the libary
 
+This example code deploys a sysclient that connects to the Devices app's websocket.
+It then serves HTTP endpoints that are accessible through the interface in the Devices app.
+It issues the requests with the received configurations on the console.
+
 ``` go
 package main
 
 import (
-	"embed"
 	"fmt"
 	"net/http"
 	"time"
@@ -22,12 +25,6 @@ import (
 )
 
 
-// this is a local folder in your project 
-// the files and dirs in this directory are build into the go binary and
-// can be requested over a tunnel connection within the device app
-
-//go:embed devices/*
-var StaticDevicesFolderFS embed.FS
 
 func main() {
 	// define the properties of the device that connects to the devices app as sysclient
@@ -41,8 +38,8 @@ func main() {
 		Fw:      "ip222.bin",
 		Bc:      "boot222.bin",
 		Mini:    false,
-        PbxActive: false,
-        Other: false,
+		PbxActive: false,
+		Other: false,
 		Platform: sysclient.Platform{
 			Type: "PHONE",
 		},
@@ -62,7 +59,7 @@ func main() {
 		
 		// the Devices App URL to connect to
         // ws[s]://<ip/host>[:<port>]/<domain></instance>/sysclients
-	    "wss://apps.company.com/company.com/devices/sysclients"
+		"wss://apps.company.com/company.com/devices/sysclients",
 
 		// a timeout duration for the websocket
 		time.Duration(2*time.Second),
@@ -90,7 +87,7 @@ func main() {
 }
 
 // create a ServeMux for handling Tunnel Http Requests
-func getServerMux() *http.ServeMux {
+func getServeMux() *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Serve a file for the /admin.xml path

--- a/sysclient/admin.go
+++ b/sysclient/admin.go
@@ -1,0 +1,246 @@
+package sysclient
+
+import (
+	"crypto/rc4"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Sysclient message header
+const (
+	MessageTypeAdmin byte = 0x01
+)
+
+// Admin message header
+var AdminSendIdentify []byte = []byte{0x00, 0x00}             // Send identify
+var AdminReceiveSysclientPassword []byte = []byte{0x00, 0x01} // Receive sysclient password
+var AdminReceiveChallenge []byte = []byte{0x00, 0x02}         // Receive challenge
+var AdminReceiveNewAdminPassword []byte = []byte{0x00, 0x03}  // Receive new administrative password
+var AdminProvision []byte = []byte{0x00, 0x04}                // Provision
+var AdminProvisionResult []byte = []byte{0x00, 0x05}          // Provision result
+var AdminConfiguration []byte = []byte{0x00, 0x06}            // Configuration
+
+// SMT | Byte offset
+//     |  0      1      2      3      4      5      6      7      8      9     ...
+//     +------+------+------+------+------+------+------+------+------+------+------+
+//  1  | Msg- |   Adm-Msg   | Data.........
+
+type AdminMessage struct {
+	Type    byte
+	Command []byte // 2 bytes
+	Data    []byte // the rest of the data
+
+}
+
+func NewAdminMessage(message []byte) (*AdminMessage, error) {
+	if len(message) < 3 { // 3 + data
+		return nil, errors.New("invalid length of AdminMessage")
+	}
+
+	m := &AdminMessage{
+		Type:    message[0],
+		Command: message[1:3],
+		Data:    message[3:],
+	}
+
+	if m.Type != MessageTypeAdmin {
+		return nil, errors.New("message is not a AdminMessage")
+	}
+
+	return m, nil
+}
+func (am *AdminMessage) AsBytes() []byte {
+	message_as_bytes := []byte{am.Type}
+	message_as_bytes = append(message_as_bytes, am.Command...)
+	message_as_bytes = append(message_as_bytes, am.Data...)
+	return message_as_bytes
+}
+
+/*
+receives the sysclient password and stores it.
+no answer is required
+*/
+func (am *AdminMessage) HandleAdminReceiveSysclientPassword(fileSysclientpassword string) error {
+	password, err_from_json := NewPassword(am.Data)
+	if err_from_json != nil {
+		return fmt.Errorf("parsing password from JSON failed: %v", err_from_json)
+	}
+	if len(password.Password) != 32 {
+		return fmt.Errorf("the password parsed from JSON has a invalid length of: %v", len(password.Password))
+	}
+
+	err := os.WriteFile(fileSysclientpassword, []byte(password.Password), 0644)
+	if err != nil {
+		return fmt.Errorf("error while writing adminpassword to file '%s': %v", fileSysclientpassword, err)
+	}
+	return nil
+}
+
+func (am *AdminMessage) HandleAdminReceiveChallenge(deviceInfo *Identity, fileSysclientpassword string) (*AdminMessage, error) {
+	challenge, err_from_json := NewChallenge(am.Data)
+	if err_from_json != nil {
+		return nil, fmt.Errorf("parsing challenge from json failed: %v", err_from_json)
+	}
+
+	if challenge.Challenge == "" {
+		return nil, fmt.Errorf("couldn't parse Challenge Message")
+	}
+	fileinfo, err_read_file := os.Stat(fileSysclientpassword)
+	if err_read_file != nil {
+		return nil, fmt.Errorf("could not read sysclientpassword from file '%s': %v", fileSysclientpassword, err_read_file)
+	}
+
+	if fileinfo.IsDir() {
+		return nil, fmt.Errorf("path is a directory: %s", fileinfo.Name())
+	}
+	password, err := os.ReadFile(fileSysclientpassword)
+	if err != nil {
+		fmt.Printf("error while reading password file: %v\n", err)
+		return nil, err
+	}
+	digest, err_digest := am.GetLoginDigest(deviceInfo.Id, deviceInfo.Product, deviceInfo.Version, challenge.Challenge, string(password))
+	if err_digest != nil {
+		return nil, err_digest
+	}
+
+	deviceInfo.Digest = digest
+	idbytes, err_to_bytes := deviceInfo.ToBytes()
+	if err_to_bytes != nil {
+		return nil, err_to_bytes
+	}
+
+	message_as_bytes := []byte{am.Type}
+	message_as_bytes = append(message_as_bytes, AdminSendIdentify...)
+	message_as_bytes = append(message_as_bytes, idbytes...)
+	return NewAdminMessage(message_as_bytes)
+
+}
+
+func (am *AdminMessage) GetLoginDigest(id, product, version, challenge, password string) (string, error) {
+	if id == "" {
+		return "", errors.New("id cant be empty")
+	}
+	if product == "" {
+		return "", errors.New("product cant be empty")
+	}
+	if version == "" {
+		return "", errors.New("version cant be empty")
+	}
+	if challenge == "" {
+		return "", errors.New("challenge cant be empty")
+	}
+	if password == "" {
+		return "", errors.New("password cant be empty")
+	}
+
+	bytes := sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s:%s:%s", id, product, version, challenge, password)))
+	digest := hex.EncodeToString(bytes[:])
+
+	return digest, nil
+}
+
+/*
+receives a admin password and stores it, no answer is required
+*/
+func (am *AdminMessage) handleAdminReceiveNewAdministrativePassword(fileSysclientpassword string, fileAdministrativePassword string) error {
+	if fileSysclientpassword == "" {
+		return errors.New("fileSysclientpassword cant be empty")
+	}
+
+	payload, err := NewAdministrativePassword(am.Data)
+	if err != nil {
+		return fmt.Errorf("couldn't parse AdministrativePassword Message: %v", err)
+	}
+
+	passwordBytes, err := os.ReadFile(fileSysclientpassword)
+	if err != nil {
+		return err
+	}
+	decryped_adminpassword, err_decrypt := am.DecryptAdminPassword(string(passwordBytes), payload.Seed, payload.Pwd)
+	if err_decrypt != nil {
+		return err_decrypt
+	}
+
+	err = os.WriteFile(fileAdministrativePassword, decryped_adminpassword, 0644)
+	if err != nil {
+		return err
+	}
+	return nil //resp, nil
+}
+
+func (am *AdminMessage) DecryptAdminPassword(sysclientPassword string, seed string, pwd string) ([]byte, error) {
+	if sysclientPassword == "" {
+		return nil, errors.New("sysclientPassword cant be empty")
+	}
+	if len(sysclientPassword) != 32 {
+		return nil, fmt.Errorf("sysclientPassword has a invalid length of '%v'. should have a length of 32", len(sysclientPassword))
+	}
+	if seed == "" {
+		return nil, errors.New("seed cant be empty")
+	}
+	if len(seed) != 16 {
+		return nil, fmt.Errorf("seed has a invalid length of '%v'. should have a length of 16", len(seed))
+	}
+
+	if pwd == "" {
+		return nil, errors.New("pwd cant be empty")
+	}
+
+	seedPassword := seed + ":" + sysclientPassword
+	key := []byte(seedPassword)
+	block, err := rc4.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	decrypted := make([]byte, len(pwd))
+	block.XORKeyStream(decrypted, []byte(pwd))
+
+	return decrypted, nil
+}
+
+type Password struct {
+	Password string `json:"password"`
+}
+
+func NewPassword(json_bytes []byte) (*Password, error) {
+	var payload Password
+	err_from_json := json.Unmarshal(json_bytes, &payload)
+	if err_from_json != nil {
+		return nil, err_from_json
+	} else {
+		return &payload, nil
+	}
+}
+
+type Challenge struct {
+	Challenge string `json:"challenge"`
+}
+
+func NewChallenge(json_bytes []byte) (*Challenge, error) {
+	var payload Challenge
+	err_from_json := json.Unmarshal(json_bytes, &payload)
+	if err_from_json != nil {
+		return nil, err_from_json
+	} else {
+		return &payload, nil
+	}
+}
+
+type AdministrativePassword struct {
+	Seed string `json:"seed"`
+	Pwd  string `json:"pwd"`
+}
+
+func NewAdministrativePassword(json_bytes []byte) (*AdministrativePassword, error) {
+	var payload AdministrativePassword
+	err_from_json := json.Unmarshal(json_bytes, &payload)
+	if err_from_json != nil {
+		return nil, err_from_json
+	} else {
+		return &payload, nil
+	}
+}

--- a/sysclient/admin_test.go
+++ b/sysclient/admin_test.go
@@ -1,0 +1,609 @@
+package sysclient_test
+
+import (
+	"testing"
+
+	"github.com/ricoschulte/go-myapps/sysclient"
+	"gotest.tools/assert"
+)
+
+func TestAdminMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+
+		Type    byte
+		Command []byte
+		Data    []byte
+
+		Error     bool
+		ErrorText string
+	}{
+		{
+			name:    "AdminSendIdentify",
+			raw:     []byte{0x01, 0x00, 0x00, 0xff, 0x00, 0xff},
+			Type:    0x01,
+			Command: []byte{0x00, 0x00},
+			Data:    []byte{0xff, 0x00, 0xff},
+
+			Error:     false,
+			ErrorText: "",
+		},
+		{
+			name: "AdminReceiveSysclientPassword",
+			raw:  []byte{0x01, 0x00, 0x01, 0xf1, 0xf2, 0xf3},
+
+			Type:    0x01,
+			Command: []byte{0x00, 0x01},
+			Data:    []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "AdminReceiveChallenge",
+			raw: []byte{0x01,
+				0x00, 0x02,
+				0xf1, 0xf2, 0xf3,
+			},
+
+			Type:    0x01,
+			Command: []byte{0x00, 0x02},
+			Data:    []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+
+			name: "AdminReceiveNewAdminPassword",
+			raw: []byte{0x01,
+				0x00, 0x03,
+				0xf1, 0xf2, 0xf3,
+			},
+
+			Type:    0x01,
+			Command: []byte{0x00, 0x03},
+			Data:    []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "AdminProvision",
+			raw: []byte{0x01,
+				0x00, 0x04,
+				0xf1, 0xf2, 0xf3,
+			},
+
+			Type:    0x01,
+			Command: []byte{0x00, 0x04},
+			Data:    []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "AdminProvisionResult",
+			raw: []byte{0x01,
+				0x00, 0x05,
+				0xf1, 0xf2, 0xf3,
+			},
+
+			Type:    0x01,
+			Command: []byte{0x00, 0x05},
+			Data:    []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "AdminConfiguration",
+			raw: []byte{0x01,
+				0x00, 0x06,
+				0xf1, 0xf2, 0xf3,
+			},
+
+			Type:      0x01,
+			Command:   []byte{0x00, 0x06},
+			Data:      []byte{0xf1, 0xf2, 0xf3},
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "Not a AdminMessage",
+			raw: []byte{0x02, // is a Tunnel message
+				0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x03, 0xf1, 0xf2, 0xf3},
+
+			Type:    0x01,
+			Command: []byte{0x00, 0x00},
+			Data:    []byte{0xff, 0x00, 0xff},
+
+			Error:     true,
+			ErrorText: "message is not a AdminMessage",
+		}, {
+			name: "Message with invalid length",
+			raw:  []byte{0x01, 0x12 /* , one missing*/},
+
+			Type:      0x01,
+			Command:   []byte{0x00, 0x01},
+			Data:      []byte{0xff, 0x00, 0xff},
+			Error:     true,
+			ErrorText: "invalid length of AdminMessage",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m, err := sysclient.NewAdminMessage(test.raw)
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+
+				assert.Equal(t, test.Type, m.Type)
+
+				assert.Equal(t, 2, len(m.Command), "Command has invalid length")
+				assert.DeepEqual(t, test.Command, m.Command)
+
+				assert.Equal(t, len(test.Data), len(m.Data), "Data has invalid length")
+				assert.DeepEqual(t, test.Data, m.Data)
+
+				assert.DeepEqual(t, test.raw, m.AsBytes())
+			}
+
+		})
+	}
+
+}
+
+func TestPasswordFromJson(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+
+		Password  string
+		Error     bool
+		ErrorText string
+	}{
+		{
+			"a",
+			`{"password":"AEF_06eOMcDANh5DKkklhVjKJ3lgVXVD"}`,
+			"AEF_06eOMcDANh5DKkklhVjKJ3lgVXVD",
+			false,
+			"",
+		},
+		{
+			"invalid json",
+			`{"password":"AEF_06eOMcDANh5DKkklhVjKJ3lgVXVD"`,
+			"AEF_06eOMcDANh5DKkklhVjKJ3lgVXVD",
+			true,
+			"unexpected end of JSON input",
+		},
+		{
+			"empty json",
+			``,
+			"AEF_06eOMcDANh5DKkklhVjKJ3lgVXVD",
+			true,
+			"unexpected end of JSON input",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m, err := sysclient.NewPassword([]byte(test.raw))
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+
+				assert.Equal(t, test.Password, m.Password)
+			}
+
+		})
+	}
+
+}
+
+func TestChallengeFromJson(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+
+		Challenge string
+		Error     bool
+		ErrorText string
+	}{
+		{
+			"ok",
+			`{"challenge":"316668907"}`,
+			"316668907",
+			false,
+			"",
+		},
+		{
+			"invalid json",
+			`{"challenge:"316668907"}`,
+			"316668907",
+			true,
+			"invalid character '3' after object key",
+		},
+		{
+			"empty bytes",
+			``,
+			"316668907",
+			true,
+			"unexpected end of JSON input",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m, err := sysclient.NewChallenge([]byte(test.raw))
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+
+				assert.Equal(t, test.Challenge, m.Challenge)
+			}
+
+		})
+	}
+
+}
+
+func TestAdministrativePasswordFromJson(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+
+		Seed      string
+		Pwd       string
+		Error     bool
+		ErrorText string
+	}{
+		{
+			"ok",
+			`{"seed":"somethingsomething","pwd":"othersomethingsomething"}`,
+			"somethingsomething",
+			"othersomethingsomething",
+			false,
+			"",
+		},
+		{
+			"invalid json",
+			`{"seed":"somethingsomething""pwd":"othersomethingsomething"}`,
+			"somethingsomething",
+			"othersomethingsomething",
+			true,
+			`invalid character '"' after object key:value pair`,
+		},
+		{
+			"empty bytes",
+			``,
+			"somethingsomething",
+			"othersomethingsomething",
+			true,
+			"unexpected end of JSON input",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m, err := sysclient.NewAdministrativePassword([]byte(test.raw))
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+
+				assert.Equal(t, test.Seed, m.Seed)
+				assert.Equal(t, test.Pwd, m.Pwd)
+			}
+
+		})
+	}
+
+}
+
+func TestDecryptAdminPassword(t *testing.T) {
+	tests := []struct {
+		name                  string
+		Seed                  string
+		Pwd                   string
+		SysclientPassword     string
+		expectedAdminPassword string
+		Error                 bool
+		ErrorText             string
+	}{
+		// #TODO it is unclear how the decrypted content should look like.
+		// at the moment its everything, but not 'test'.
+		// i dont know if the decrypted value is still encrypted in a way, a device can be configured with it.
+		
+		// {
+		// 	name:                  "a",
+		// 	Seed:                  "wJQog70GUK!GPTN2",
+		// 	Pwd:                   "22f91ebb",
+		// 	SysclientPassword:     "7iICN04agQq38j!hmbN7P5LLI1YePz1w",
+		// 	expectedAdminPassword: "test",  <----- problem
+		// 	Error:                 false,
+		// 	ErrorText:             "",
+		// },
+		// {
+		// 	name:                  "b",
+		// 	Seed:                  "RlGIgQj2j!LUIgPL",
+		// 	Pwd:                   "cfa78653",
+		// 	SysclientPassword:     "N803pDZVpL_ccS_1tGwFjIN0cfw75MNo",
+		// 	expectedAdminPassword: "test",  <----- problem
+		// 	Error:                 false,
+		// 	ErrorText:             "",
+		// },
+		{
+			name: "empty seed",
+			//Seed:                  "1234567812345678",
+			Pwd:                   "sdfsdf",
+			SysclientPassword:     "12345678123456781234567812345678",
+			expectedAdminPassword: "sdfsdf",
+			Error:                 true,
+			ErrorText:             "seed cant be empty",
+		},
+		{
+			name:                  "invalid seed length",
+			Seed:                  "1234567812345678_",
+			Pwd:                   "sdfsdf",
+			SysclientPassword:     "12345678123456781234567812345678",
+			expectedAdminPassword: "sdfsdf",
+			Error:                 true,
+			ErrorText:             "seed has a invalid length of '17'. should have a length of 16",
+		},
+		{
+			name: "empty pwd",
+			Seed: "1234567812345678",
+			//Pwd:                   "sdfsdf",
+			SysclientPassword:     "12345678123456781234567812345678",
+			expectedAdminPassword: "sdfswrzw34",
+			Error:                 true,
+			ErrorText:             "pwd cant be empty",
+		},
+		{
+			name: "empty sysclient",
+			Seed: "1234567812345678",
+			Pwd:  "sdfsdf",
+			//SysclientPassword:     "12345678123456781234567812345678",
+			expectedAdminPassword: "defdsshh",
+			Error:                 true,
+			ErrorText:             "sysclientPassword cant be empty",
+		},
+		{
+			name:                  "invalid sysclientpassword length",
+			Seed:                  "1234567812345678",
+			Pwd:                   "sdfsdf",
+			SysclientPassword:     "1234567812345678123__4567812345678",
+			expectedAdminPassword: "defdsshh",
+			Error:                 true,
+			ErrorText:             "sysclientPassword has a invalid length of '34'. should have a length of 32",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bin := []byte{sysclient.MessageTypeAdmin}
+			bin = append(bin, sysclient.AdminReceiveNewAdminPassword...)
+			m, err_am := sysclient.NewAdminMessage(bin)
+			if err_am != nil {
+				t.Fatal("error creating test AM instance")
+			}
+
+			adminpwd_bytes, err := m.DecryptAdminPassword(test.SysclientPassword, test.Seed, test.Pwd)
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+
+				assert.Equal(t, test.expectedAdminPassword, string(adminpwd_bytes))
+			}
+
+		})
+	}
+
+}
+
+func TestGetLoginDigest(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		id             string
+		product        string
+		version        string
+		challenge      string
+		password       string
+		expectedDigest string
+		Error          bool
+		ErrorText      string
+	}{
+		{
+			name:           "a",
+			id:             "f19033480af9",
+			product:        "IP232",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "1446931255",
+			password:       "2jjH!u3ucXscEzHq8X!l83BX3!U8TPwA",
+			expectedDigest: "13cc86b3f0691e2ce1a626a9963a5aefeefcb78f7e5b23a8ede10e8204247c97",
+			Error:          false,
+			ErrorText:      "",
+		},
+		{
+			name:           "b",
+			id:             "f19033480af9",
+			product:        "IP232",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "616692991",
+			password:       "2jjH!u3ucXscEzHq8X!l83BX3!U8TPwA",
+			expectedDigest: "dcbf704513ba5f771aabc5ba553ab82928c51cd69ef1c010174086f5b82414a8",
+			Error:          false,
+			ErrorText:      "",
+		},
+		{
+			name:           "c",
+			id:             "f19033480af9",
+			product:        "IP222",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "931977739",
+			password:       "q19rykt45KceQbEyN8rXPLQlb4VZRvn7",
+			expectedDigest: "75c2d186d072f9a22e797c4c1978d8f2f00185c2cce28d02515617368aec4ed4",
+			Error:          false,
+			ErrorText:      "",
+		},
+		{
+			name:           "d",
+			id:             "f19033480af9",
+			product:        "IP222",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "201737720",
+			password:       "q19rykt45KceQbEyN8rXPLQlb4VZRvn7",
+			expectedDigest: "939f89c2fe801cf4a2217b3db94e1f9c1e24544b03a303f716e9c60878eff9d6",
+			Error:          false,
+			ErrorText:      "",
+		},
+		{
+			name:           "e",
+			id:             "f19033480af9",
+			product:        "IP222",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "571341503",
+			password:       "boO!fTk!YepvjmYPS6ejgTVzh6DrD6vo",
+			expectedDigest: "d8c5c3d118890df9a9439d40941f2e6be136942374a4736cd687ab4ea96f8f90",
+			Error:          false,
+			ErrorText:      "",
+		},
+		{
+			name:           "f",
+			id:             "f19033480af9",
+			product:        "IP222",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "1404833035",
+			password:       "boO!fTk!YepvjmYPS6ejgTVzh6DrD6vo",
+			expectedDigest: "e8ce86a0395ad01d09dc08ca44195f3613bfb3d8407d9e9a9f2d15907be9f351",
+			Error:          false,
+			ErrorText:      "",
+		},
+
+		{
+			name: "empty id",
+			//id:             "f09033480af9",
+			product:        "IP222",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "sdsdfsd",
+			password:       "sdfsdf",
+			expectedDigest: "",
+			Error:          true,
+			ErrorText:      "id cant be empty",
+		},
+		{
+			name: "empty product",
+			id:   "f09033480af9",
+			//product:        "IP222",
+			version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "sdsdfsd",
+			password:       "sdfsdf",
+			expectedDigest: "",
+			Error:          true,
+			ErrorText:      "product cant be empty",
+		},
+		{
+			name:    "empty version",
+			id:      "f09033480af9",
+			product: "IP222",
+			//version:        "13r2 dvl [13.4250/131286/1300]",
+			challenge:      "sdsdfsd",
+			password:       "sdfsdf",
+			expectedDigest: "",
+			Error:          true,
+			ErrorText:      "version cant be empty",
+		},
+		{
+			name:    "empty challenge",
+			id:      "f09033480af9",
+			product: "IP222",
+			version: "13r2 dvl [13.4250/131286/1300]",
+			//challenge:      "sdsdfsd",
+			password:       "sdfsdf",
+			expectedDigest: "",
+			Error:          true,
+			ErrorText:      "challenge cant be empty",
+		},
+		{
+			name:      "empty password",
+			id:        "f09033480af9",
+			product:   "IP222",
+			version:   "13r2 dvl [13.4250/131286/1300]",
+			challenge: "sdsdfsd",
+			//password:       "sdfsdf",
+			expectedDigest: "",
+			Error:          true,
+			ErrorText:      "password cant be empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bin := []byte{sysclient.MessageTypeAdmin}
+			bin = append(bin, sysclient.AdminReceiveNewAdminPassword...)
+			m, err_am := sysclient.NewAdminMessage(bin)
+			if err_am != nil {
+				t.Fatal("error creating test AM instance")
+			}
+
+			digest_string, err := m.GetLoginDigest(
+				test.id,
+				test.product,
+				test.version,
+				test.challenge,
+				test.password,
+			)
+
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+				assert.Equal(t, test.expectedDigest, string(digest_string))
+			}
+		})
+	}
+}

--- a/sysclient/identity.go
+++ b/sysclient/identity.go
@@ -1,0 +1,48 @@
+package sysclient
+
+import "encoding/json"
+
+type Platform struct {
+	Type string `json:"type"`
+	Fxs  bool   `json:"fxs"`
+}
+
+type EthIf struct {
+	If   string `json:"if"`
+	Ipv4 string `json:"ipv4"`
+	Ipv6 string `json:"ipv6"`
+}
+
+type Identity struct {
+	Id        string   `json:"id"`
+	Product   string   `json:"product"`
+	Version   string   `json:"version"`
+	FwBuild   string   `json:"fwBuild"`
+	BcBuild   string   `json:"bcBuild"`
+	Major     string   `json:"major"`
+	Fw        string   `json:"fw"`
+	Bc        string   `json:"bc"`
+	Mini      bool     `json:"mini"`
+	PbxActive bool     `json:"pbxActive"`
+	Other     bool     `json:"other"`
+	Platform  Platform `json:"platform"`
+	Digest    string   `json:"digest,omitempty"`
+	EthIfs    []EthIf  `json:"ethIfs,omitempty"`
+}
+
+func NewIdentity(json_bytes []byte) (*Identity, error) {
+	var identity Identity
+	err := json.Unmarshal(json_bytes, &identity)
+	if err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}
+
+func (i Identity) ToBytes() ([]byte, error) {
+	msgbytes, err_to_json := json.Marshal(i)
+	if err_to_json != nil {
+		return nil, err_to_json
+	}
+	return msgbytes, nil
+}

--- a/sysclient/identity_test.go
+++ b/sysclient/identity_test.go
@@ -1,0 +1,201 @@
+package sysclient_test
+
+import (
+	"testing"
+
+	"github.com/ricoschulte/go-myapps/sysclient"
+	"gotest.tools/assert"
+)
+
+func TestMarshalIdentifyMessage(t *testing.T) {
+	tests := []struct {
+		Name string
+
+		Id           string
+		Product      string
+		Version      string
+		FwBuild      string
+		BcBuild      string
+		Major        string
+		Fw           string
+		Bc           string
+		Mini         bool
+		PbxActive    bool
+		Other        bool
+		Platform     sysclient.Platform
+		Digest       string
+		EthIfs       []sysclient.EthIf
+		expectedJson string
+	}{
+		{
+			Name:      "all booleans false",
+			Id:        "f09033480af9",
+			Product:   "IP222",
+			Version:   "13r2 dvl [13.4250/131286/1300]",
+			FwBuild:   "134250",
+			BcBuild:   "131286",
+			Major:     "13r2",
+			Fw:        "ip222.bin",
+			Bc:        "boot222.bin",
+			Mini:      false,
+			PbxActive: false,
+			Other:     false,
+			Platform: sysclient.Platform{
+				Type: "PHONE",
+				Fxs:  false,
+			},
+			Digest: "f3d37205d8eb93a4770035853c12984",
+			EthIfs: []sysclient.EthIf{
+				{
+					If:   "ETH0",
+					Ipv4: "172.16.4.141",
+					Ipv6: "2002:91fd:9d07:0:290:33ff:fe46:af2",
+				},
+			},
+			expectedJson: `{"id":"f09033480af9","product":"IP222","version":"13r2 dvl [13.4250/131286/1300]","fwBuild":"134250","bcBuild":"131286","major":"13r2","fw":"ip222.bin","bc":"boot222.bin","mini":false,"pbxActive":false,"other":false,"platform":{"type":"PHONE","fxs":false},"digest":"f3d37205d8eb93a4770035853c12984","ethIfs":[{"if":"ETH0","ipv4":"172.16.4.141","ipv6":"2002:91fd:9d07:0:290:33ff:fe46:af2"}]}`,
+		},
+		{
+			Name:      "no EthIfs",
+			Id:        "f09033480af9",
+			Product:   "IP222",
+			Version:   "13r2 dvl [13.4250/131286/1300]",
+			FwBuild:   "134250",
+			BcBuild:   "131286",
+			Major:     "13r2",
+			Fw:        "ip222.bin",
+			Bc:        "boot222.bin",
+			Mini:      false,
+			PbxActive: false,
+			Other:     false,
+			Platform: sysclient.Platform{
+				Type: "PHONE",
+				Fxs:  false,
+			},
+			Digest: "f3d37205d8eb93a4770035853c12984",
+			// EthIfs: []sysclient.EthIf{
+			// 	{
+			// 		If:   "ETH0",
+			// 		Ipv4: "172.16.4.141",
+			// 		Ipv6: "2002:91fd:9d07:0:290:33ff:fe46:af2",
+			// 	},
+			// },
+			expectedJson: `{"id":"f09033480af9","product":"IP222","version":"13r2 dvl [13.4250/131286/1300]","fwBuild":"134250","bcBuild":"131286","major":"13r2","fw":"ip222.bin","bc":"boot222.bin","mini":false,"pbxActive":false,"other":false,"platform":{"type":"PHONE","fxs":false},"digest":"f3d37205d8eb93a4770035853c12984"}`,
+		},
+		{
+			Name:      "two EthIfs",
+			Id:        "f09033480af9",
+			Product:   "IP222",
+			Version:   "13r2 dvl [13.4250/131286/1300]",
+			FwBuild:   "134250",
+			BcBuild:   "131286",
+			Major:     "13r2",
+			Fw:        "ip222.bin",
+			Bc:        "boot222.bin",
+			Mini:      false,
+			PbxActive: false,
+			Other:     false,
+			Platform: sysclient.Platform{
+				Type: "PHONE",
+				Fxs:  false,
+			},
+			//Digest: "f3d37205d8eb93a4770035853c12984",
+			EthIfs: []sysclient.EthIf{
+				{
+					If:   "ETH0",
+					Ipv4: "172.16.4.141",
+					Ipv6: "2002:91fd:9d07:0:290:33ff:fe46:af2",
+				},
+				{
+					If:   "ETH1",
+					Ipv4: "172.16.2.141",
+					Ipv6: "2002:91fd:9d07:1:290:33ff:fe46:af2",
+				},
+			},
+			expectedJson: `{"id":"f09033480af9","product":"IP222","version":"13r2 dvl [13.4250/131286/1300]","fwBuild":"134250","bcBuild":"131286","major":"13r2","fw":"ip222.bin","bc":"boot222.bin","mini":false,"pbxActive":false,"other":false,"platform":{"type":"PHONE","fxs":false},"ethIfs":[{"if":"ETH0","ipv4":"172.16.4.141","ipv6":"2002:91fd:9d07:0:290:33ff:fe46:af2"},{"if":"ETH1","ipv4":"172.16.2.141","ipv6":"2002:91fd:9d07:1:290:33ff:fe46:af2"}]}`,
+		},
+		{
+			Name:      "no digest",
+			Id:        "f09033480af9",
+			Product:   "IP222",
+			Version:   "13r2 dvl [13.4250/131286/1300]",
+			FwBuild:   "134250",
+			BcBuild:   "131286",
+			Major:     "13r2",
+			Fw:        "ip222.bin",
+			Bc:        "boot222.bin",
+			Mini:      false,
+			PbxActive: false,
+			Other:     false,
+			Platform: sysclient.Platform{
+				Type: "PHONE",
+				Fxs:  false,
+			},
+			//Digest: "f3d37205d8eb93a4770035853c12984",
+			EthIfs: []sysclient.EthIf{
+				{
+					If:   "ETH0",
+					Ipv4: "172.16.4.141",
+					Ipv6: "2002:91fd:9d07:0:290:33ff:fe46:af2",
+				},
+			},
+			expectedJson: `{"id":"f09033480af9","product":"IP222","version":"13r2 dvl [13.4250/131286/1300]","fwBuild":"134250","bcBuild":"131286","major":"13r2","fw":"ip222.bin","bc":"boot222.bin","mini":false,"pbxActive":false,"other":false,"platform":{"type":"PHONE","fxs":false},"ethIfs":[{"if":"ETH0","ipv4":"172.16.4.141","ipv6":"2002:91fd:9d07:0:290:33ff:fe46:af2"}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			identityA := sysclient.Identity{
+				Id:        test.Id,
+				Product:   test.Product,
+				Version:   test.Version,
+				FwBuild:   test.FwBuild,
+				BcBuild:   test.BcBuild,
+				Major:     test.Major,
+				Fw:        test.Fw,
+				Bc:        test.Bc,
+				Mini:      test.Mini,
+				PbxActive: test.PbxActive,
+				Other:     test.Other,
+				Platform: sysclient.Platform{
+					Type: test.Platform.Type,
+					Fxs:  test.Platform.Fxs,
+				},
+				Digest: test.Digest,
+				EthIfs: test.EthIfs,
+			}
+
+			// convert to Json
+			json_bytes, err := identityA.ToBytes()
+			assert.NilError(t, err, "converting to bytes failed with error")
+			assert.DeepEqual(t, test.expectedJson, string(json_bytes))
+
+			// convert from Bytes to Instance
+			identity, err_parsing := sysclient.NewIdentity(json_bytes)
+			assert.NilError(t, err_parsing, "error parsing from json")
+
+			assert.Equal(t, test.Id, identity.Id, "Id is not the expected one")
+			assert.Equal(t, test.Product, identity.Product, "Product is not the expected one")
+			assert.Equal(t, test.Version, identity.Version, "Version is not the expected one")
+			assert.Equal(t, test.FwBuild, identity.FwBuild, "FwBuild is not the expected one")
+			assert.Equal(t, test.BcBuild, identity.BcBuild, "BcBuild is not the expected one")
+			assert.Equal(t, test.Major, identity.Major, "Major is not the expected one")
+			assert.Equal(t, test.Fw, identity.Fw, "Fw is not the expected one")
+			assert.Equal(t, test.Bc, identity.Bc, "Bc is not the expected one")
+			assert.Equal(t, test.Mini, identity.Mini, "Mini is not the expected one")
+			assert.Equal(t, test.PbxActive, identity.PbxActive, "PbxActive is not the expected one")
+			assert.Equal(t, test.Other, identity.Other, "Other is not the expected one")
+			assert.Equal(t, test.Platform, identity.Platform, "Platform is not the expected one")
+			assert.Equal(t, test.Digest, identity.Digest, "Digest is not the expected one")
+			assert.Equal(t, test.Platform, identity.Platform, "Platform is not the expected one")
+			for i, eth := range test.EthIfs {
+				assert.Equal(t, test.EthIfs[i].If, eth.If, "EthIfs.If is not the expected one")
+				assert.Equal(t, test.EthIfs[i].Ipv4, eth.Ipv4, "EthIfs.Ipv4 is not the expected one")
+				assert.Equal(t, test.EthIfs[i].Ipv6, eth.Ipv6, "EthIfs.Ipv6 is not the expected one")
+			}
+			assert.Equal(t, test.Platform, identity.Platform, "Platform is not the expected one")
+			assert.Equal(t, test.Platform, identity.Platform, "Platform is not the expected one")
+
+		})
+	}
+
+}

--- a/sysclient/sysclient.go
+++ b/sysclient/sysclient.go
@@ -1,0 +1,260 @@
+package sysclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/ricoschulte/go-myapps/connection"
+)
+
+
+type Sysclient struct {
+	Identity           Identity
+	Url                string
+	Timeout            time.Duration
+	InsecureSkipVerify bool
+	Context            context.Context
+	Conn               *websocket.Conn
+	Tunnels            map[int32]*SysclientTunnel // map of active tunnels indexed by the sessionid
+	ServeMux           *http.ServeMux             // the instance of the Http Server Mux to handle Http Requests
+
+	FileSysclientPassword      string // filename to store
+	FileAdministrativePassword string // filename to store
+}
+
+func NewSysclient(identity Identity, url string, timeout time.Duration, insecureSkipVerify bool, mux *http.ServeMux, fileSysclientPassword string, fileAdministrativePassword string) (*Sysclient, error) {
+	if fileSysclientPassword == "" {
+		return nil, errors.New("fileSysclientPassword cant be empty")
+	}
+	if fileAdministrativePassword == "" {
+		return nil, errors.New("fileAdministrativePassword cant be empty")
+	}
+
+	sysclient := &Sysclient{
+		Identity:           identity,
+		Url:                url,
+		Timeout:            timeout,
+		InsecureSkipVerify: insecureSkipVerify,
+		Tunnels:            map[int32]*SysclientTunnel{},
+		ServeMux:           mux,
+
+		FileSysclientPassword:      fileSysclientPassword,
+		FileAdministrativePassword: fileAdministrativePassword,
+	}
+
+	return sysclient, nil
+
+}
+func (sc *Sysclient) Println(v ...any) {
+	log.Printf("{%s}\n", v...)
+
+}
+
+func (sc *Sysclient) Printf(format string, a ...interface{}) {
+	log.Printf("{%s} %s\n", "sysclient", fmt.Sprintf(format, a...))
+
+}
+
+func (sc *Sysclient) Connect() error {
+
+	for {
+		sc.Printf("connecting to %s as %v/%v", sc.Url, sc.Identity.Id, sc.Identity.Product)
+
+		// Dialer configuration
+		dialer := websocket.DefaultDialer
+
+		// if `config.InsecureSkipVerify` is set to true, the TLS/SSL certificate is not checked
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: sc.InsecureSkipVerify}
+
+		// Connect to the WebSocket
+		ctx, cancel := context.WithTimeout(context.Background(), connection.ReconnectTimeout)
+		conn, _, err := dialer.DialContext(ctx, sc.Url, http.Header{})
+		if err != nil {
+			sc.Printf("error while connecting to url '%s': %+v", sc.Url, err)
+			time.Sleep(connection.ReconnectTimeout) // wait before trying to reconnect, avoid hammering
+			cancel()                                // call cancel function here, It's used to stop the context's timer.
+			continue
+		}
+
+		sc.Context = ctx
+		sc.Conn = conn
+
+		// Add onDisconnect function
+		conn.SetCloseHandler(func(code int, text string) error {
+			fmt.Printf("connection closed %v %v", code, text)
+			sc.onDisconnect(code, text)
+			cancel()
+			conn.Close()
+			return nil
+		})
+
+		err_handler := sc.onConnect()
+		if err_handler != nil {
+			sc.Printf("Error in onConnect: %v", err_handler)
+		}
+
+		sc.Println("WebSocket disconnected")
+		time.Sleep(connection.ReconnectTimeout) // wait before trying to reconnect
+	}
+
+}
+
+func (sc *Sysclient) onConnect() error {
+	sc.Printf("WebSocket to '%s' connected", sc.Url)
+	mess := []byte{MessageTypeAdmin}
+	mess = append(mess, AdminSendIdentify...)
+
+	msgb, err := sc.Identity.ToBytes()
+	if err != nil {
+		return err
+	}
+	mess = append(mess, msgb...)
+
+	identify, err_message := NewAdminMessage(mess)
+	if err_message != nil {
+		return err_message
+	}
+	err_send := sc.Send(identify.AsBytes())
+	if err_send != nil {
+		return err_send
+	}
+	return sc.ReadWriteLoop()
+
+}
+
+func (sc *Sysclient) onDisconnect(code int, text string) error {
+	sc.Printf("WebSocket to '%s' disconnected: %v %v", sc.Url, code, text)
+	return nil
+}
+
+func (sc *Sysclient) Send(message []byte) error {
+	//sc.Printf("+++++++++++++++++++ Sysclient Send: %v\n\n", message)
+	err := sc.Conn.WriteMessage(websocket.BinaryMessage, message)
+	if err != nil {
+		fmt.Println("Error sending message:", err)
+		return err
+	}
+	return nil
+}
+
+func (sc *Sysclient) ReadWriteLoop() error {
+	for {
+		// Read message
+		messagetype, message, err := sc.Conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				sc.Printf("error: %v", err)
+				return err
+			}
+			if websocket.IsCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				sc.Println("server: websocket closed")
+				return err
+			}
+			break
+		}
+		if messagetype == websocket.BinaryMessage {
+			sc.received(message)
+		}
+
+	}
+	return nil
+}
+
+// called when we received a message from the appservice
+func (sc *Sysclient) received(message []byte) error {
+	if len(message) < 3 {
+		return fmt.Errorf("invalid length of message: %v", len(message))
+	}
+	//	fmt.Printf("\n\n+++++++++++++++++++ Sysclient received: %v\n", message)
+	switch message[0] {
+	default:
+		return fmt.Errorf("received unknown message from the sysclient server: %v", string(message[0]))
+	case MessageTypeAdmin:
+		msg, err_message := NewAdminMessage(message)
+		if err_message != nil {
+			return fmt.Errorf("invalid message: %v", err_message)
+		}
+
+		response, err_response := sc.HandleAdminMessage(msg)
+		if err_response != nil {
+			return err_response
+		}
+
+		// if we need to send a response
+		if response != nil {
+			err_send := sc.Send(response.AsBytes())
+			if err_send != nil {
+				return err_send
+			}
+		}
+	case MessageTypeTunnel:
+
+		msg_received, err_message := NewTunnelMessage(message)
+		if err_message != nil {
+			return fmt.Errorf("invalid message: %v", err_message)
+		}
+		msg_received_tunnel_id, err_tunnelId := msg_received.GetSessionId()
+		if err_tunnelId != nil {
+			return fmt.Errorf("invalid message: %v", err_tunnelId)
+		}
+
+		tunnel := sc.Tunnels[msg_received_tunnel_id]
+		if tunnel == nil {
+			// create a new tunnel for that sessionId
+			tunnel_new, err_create_tunnel := NewSysclientTunnel(msg_received.SessionId, sc.ServeMux)
+			if err_create_tunnel != nil {
+				return fmt.Errorf("error while creating new tunnelsession: %v", err_create_tunnel)
+			}
+			sc.Tunnels[msg_received_tunnel_id] = tunnel_new
+			tunnel = tunnel_new
+		}
+
+		response, err_handle := tunnel.HandleRequest(msg_received)
+		if err_handle != nil {
+			return err_handle
+		}
+
+		// remove closed tunnel from list
+		if bytes.Equal(response.EventType, TunnelShutdown) {
+			sc.Tunnels[msg_received_tunnel_id] = nil
+		}
+
+		err_send := sc.Send(response.AsBytes())
+		if err_send != nil {
+			return err_send
+		}
+
+	}
+
+	return nil
+}
+
+func (sc *Sysclient) HandleAdminMessage(messageIn *AdminMessage) (*AdminMessage, error) {
+	switch true {
+	default:
+		return nil, fmt.Errorf("unknown Admin Message of Type %v", messageIn.Type)
+
+	case bytes.Equal(messageIn.Command, AdminReceiveSysclientPassword):
+		err := messageIn.HandleAdminReceiveSysclientPassword(sc.FileSysclientPassword)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	case bytes.Equal(messageIn.Command, AdminReceiveChallenge):
+		return messageIn.HandleAdminReceiveChallenge(&sc.Identity, sc.FileSysclientPassword)
+
+	case bytes.Equal(messageIn.Command, AdminReceiveNewAdminPassword):
+		err := messageIn.handleAdminReceiveNewAdministrativePassword(sc.FileSysclientPassword, sc.FileAdministrativePassword)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+}

--- a/sysclient/sysclient_test.go
+++ b/sysclient/sysclient_test.go
@@ -1,0 +1,168 @@
+package sysclient_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ricoschulte/go-myapps/sysclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponseTypesToAdminMessages(t *testing.T) {
+	sysclientpassword := "2jjH!u3ucXscEzHq8X!l83BX3!U8TPwA"
+
+	// create a dummy password file
+	sysclientpassword_file, err := ioutil.TempFile("", "sysclientpassword*.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(sysclientpassword_file.Name()) // remove the file after the test is done
+
+	// create a dummy admin password file
+	administrativepassword_file, err := ioutil.TempFile("", "sysclient_administrativepassword*.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(administrativepassword_file.Name()) // remove the file after the test is done
+
+	// reset the content after the test
+	_, err = sysclientpassword_file.Write([]byte(sysclientpassword))
+	if err != nil {
+		panic(err)
+	}
+
+	identity := sysclient.Identity{
+		Id:      "f19033480af9",
+		Product: "IP232",
+		Version: "13r2 dvl [13.4250/131286/1300]",
+		FwBuild: "134250",
+		BcBuild: "131286",
+		Major:   "13r2",
+		Fw:      "ip222.bin",
+		Bc:      "boot222.bin",
+		Mini:    false,
+		Platform: sysclient.Platform{
+			Type: "PHONE",
+		},
+		EthIfs: []sysclient.EthIf{
+			{
+				If:   "ETH0",
+				Ipv4: "172.16.4.141",
+				Ipv6: "2002:91fd:9d07:0:290:33ff:fe46:af2",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+
+		// message in
+		TypeIn    byte
+		CommandIn []byte
+		DataIn    []byte
+
+		// response message
+
+		Type           byte
+		Command        []byte
+		Data           []byte
+		expectNoRepose bool
+		expectError    bool
+	}{
+		{
+			name: "AdminReceiveChallenge to AdminSendIdentify with digest",
+
+			TypeIn:    sysclient.MessageTypeAdmin,
+			CommandIn: sysclient.AdminReceiveChallenge,
+			DataIn:    []byte(`{"challenge":"1446931255"}`),
+
+			Type:    sysclient.MessageTypeAdmin,
+			Command: sysclient.AdminSendIdentify,
+			Data:    []byte(string(`{"id":"f19033480af9","product":"IP232","version":"13r2 dvl [13.4250/131286/1300]","fwBuild":"134250","bcBuild":"131286","major":"13r2","fw":"ip222.bin","bc":"boot222.bin","mini":false,"pbxActive":false,"other":false,"platform":{"type":"PHONE","fxs":false},"digest":"13cc86b3f0691e2ce1a626a9963a5aefeefcb78f7e5b23a8ede10e8204247c97","ethIfs":[{"if":"ETH0","ipv4":"172.16.4.141","ipv6":"2002:91fd:9d07:0:290:33ff:fe46:af2"}]}`)),
+
+			expectNoRepose: false,
+			expectError:    false,
+		},
+		{
+			name: "AdminReceiveSysclientPassword",
+
+			TypeIn:    sysclient.MessageTypeAdmin,
+			CommandIn: sysclient.AdminReceiveSysclientPassword,
+			DataIn:    []byte(`{"password":"01234567890123456789012345678901"}`),
+
+			Type:    0x00,
+			Command: []byte{},
+			Data:    []byte{},
+
+			expectNoRepose: true,
+			expectError:    false,
+		},
+		{
+			name: "AdminReceiveNewAdminPassword",
+
+			TypeIn:    sysclient.MessageTypeAdmin,
+			CommandIn: sysclient.AdminReceiveNewAdminPassword,
+			DataIn:    []byte(`{"seed":"0123456789012345", "pwd": "dummycontent"}`),
+
+			Type:    0x00,
+			Command: []byte{},
+			Data:    []byte{},
+
+			expectNoRepose: true,
+			expectError:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// create the input / request message
+			bam := []byte{test.TypeIn}
+			bam = append(bam, test.CommandIn...)
+			bam = append(bam, test.DataIn...)
+			am, err_am := sysclient.NewAdminMessage(bam)
+			assert.NoErrorf(t, err_am, "Error creating testmessage: %v", err_am)
+
+			// create the sysclient
+			sc, err_creating_client := sysclient.NewSysclient(
+				identity,
+				"wss://nourl",
+				time.Duration(2*time.Second),
+				true,
+				http.NewServeMux(),
+				sysclientpassword_file.Name(),
+				administrativepassword_file.Name(),
+			)
+			if err_creating_client != nil {
+				t.Fatalf("Error creating client: %v", err_creating_client)
+			}
+
+			// send the test message to the client
+			resp, err_handle := sc.HandleAdminMessage(am)
+			if test.expectError {
+				if err_handle == nil {
+					t.Fatalf("a error is expected, but there was none")
+				}
+			} else {
+				assert.NoError(t, err_handle, "error while handling the request")
+				// testing the response
+				if test.expectNoRepose {
+					assert.Nil(t, resp, "the input message should not produce a response, but has.")
+				} else {
+					assert.NotNil(t, resp, "the response is nil")
+					assert.NoErrorf(t, err_am, "Error handling request: %v", err_handle)
+					assert.Equal(t, test.Type, resp.Type)
+					assert.Equal(t, test.Command, resp.Command)
+					assert.Equal(t, test.Data, resp.Data)
+
+				}
+
+			}
+		})
+
+	}
+
+}

--- a/sysclient/tunnel.go
+++ b/sysclient/tunnel.go
@@ -1,0 +1,247 @@
+package sysclient
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// split Tunnel responses into chunks of this size of []byte
+var chunkSize = 8000
+
+// Sysclient message header
+var (
+	MessageTypeTunnel byte = 0x02
+
+	TunnelSend          []byte = []byte{0x00, 0x00, 0x00, 0x00} // socket send
+	TunnelReceive       []byte = []byte{0x00, 0x00, 0x00, 0x01} // socket receive
+	TunnelReceiveResult []byte = []byte{0x00, 0x00, 0x00, 0x02} // receive result
+	TunnelSendResult    []byte = []byte{0x00, 0x00, 0x00, 0x03} // socket send result
+	TunnelShutdown      []byte = []byte{0x00, 0x00, 0x00, 0x04} // socket shutdown
+)
+
+// SMT | Byte offset
+//
+//	   |  0      1      2      3      4      5      6      7      8      9     ...
+//	   +------+------+------+------+------+------+------+------+------+------+------+
+//	2  |      |        Session-ID         |         Event-Type        |  Data.....
+//	   +------+------+------+------+------+------+------+------+------+------+------+
+type TunnelMessage struct {
+	Type      byte
+	SessionId []byte // 4 bytes
+	EventType []byte // 4 bytes
+	Data      []byte // rest of the bytes
+}
+
+func NewTunnelMessage(message []byte) (*TunnelMessage, error) {
+	if len(message) < 9 {
+		return nil, errors.New("invalid length of message")
+	}
+
+	m := &TunnelMessage{
+		Type:      message[0],
+		SessionId: message[1:5],
+		EventType: message[5:9],
+		Data:      message[9:],
+	}
+
+	if m.Type != MessageTypeTunnel {
+		return nil, errors.New("message is not a TunnelMessage")
+	}
+
+	return m, nil
+}
+
+func (tm *TunnelMessage) GetSessionId() (int32, error) {
+
+	if len(tm.SessionId) != 4 {
+		return int32(0), errors.New("invalid length of SessionId to convert to int32")
+	}
+	return int32(binary.BigEndian.Uint32(tm.SessionId)), nil
+}
+
+func (tm *TunnelMessage) AsBytes() []byte {
+	message_as_bytes := []byte{tm.Type}
+	message_as_bytes = append(message_as_bytes, tm.SessionId...)
+	message_as_bytes = append(message_as_bytes, tm.EventType...)
+	message_as_bytes = append(message_as_bytes, tm.Data...)
+	return message_as_bytes
+}
+
+type SysclientTunnel struct {
+	ServeMux       *http.ServeMux
+	SessionId      []byte
+	Response       []byte
+	ResponseChunks [][]byte
+}
+
+func NewSysclientTunnel(session []byte, servermux *http.ServeMux) (*SysclientTunnel, error) {
+
+	tunnel := &SysclientTunnel{}
+	tunnel.ServeMux = servermux
+	tunnel.SessionId = session
+	tunnel.Response = []byte{}
+	tunnel.ResponseChunks = [][]byte{}
+
+	return tunnel, nil
+}
+
+func (tunnel *SysclientTunnel) HandleRequest(message *TunnelMessage) (*TunnelMessage, error) {
+
+	switch true {
+	default:
+		return nil, fmt.Errorf("unknown MessageType: %v", message.EventType)
+	case bytes.Equal(message.EventType, TunnelSend):
+		resp, err_handle := tunnel.HandleTunnelSend(message)
+		if err_handle != nil {
+			return nil, err_handle
+		}
+		return resp, nil
+	case bytes.Equal(message.EventType, TunnelReceive):
+		resp, err_handle := tunnel.HandleTunnelReceive(message)
+		if err_handle != nil {
+			return nil, err_handle
+		}
+		return resp, nil
+	case bytes.Equal(message.EventType, TunnelShutdown):
+		response_bytes := []byte{MessageTypeTunnel}
+		response_bytes = append(response_bytes, tunnel.SessionId...)
+		response_bytes = append(response_bytes, TunnelShutdown...)
+		resp, err_responsemessage := NewTunnelMessage(response_bytes)
+		if err_responsemessage != nil {
+			return nil, err_responsemessage
+		}
+		return resp, nil
+
+	}
+
+}
+func (tunnel *SysclientTunnel) GetNextChunk() ([]byte, error) {
+	if len(tunnel.ResponseChunks) > 0 {
+		return tunnel.ResponseChunks[0], nil
+	} else {
+		return nil, errors.New("no chunks left to respond")
+	}
+}
+
+/*
+the sysclient server is requesting data with http data
+
+	in:
+		TunnelSend
+		02 0000000d 00000000 474554202f7374617469632f6a732f706167652e6a7320485454502f312e310d0a486f73743a20617070732e667269747a2e626f780d0a…]
+	out:
+		TunnelSendResult
+		02 0000000d 00000003
+*/
+func (tunnel *SysclientTunnel) HandleTunnelSend(message *TunnelMessage) (*TunnelMessage, error) {
+	// read Data of input http
+	request, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(message.Data)))
+	if err != nil {
+		return nil, fmt.Errorf("error reading request: %v", err)
+	}
+
+	// Use the custom request handler to handle the custom request
+	w := &HttpResponseWriter{}
+	tunnel.ServeMux.ServeHTTP(w, request)
+
+	tunnel.Response = w.GetBytes()
+
+	// split http response to chunks if needed
+	for i := 0; i < len(tunnel.Response); i += chunkSize {
+		end := i + chunkSize
+		if end > len(tunnel.Response) {
+			end = len(tunnel.Response)
+		}
+		tunnel.ResponseChunks = append(tunnel.ResponseChunks, tunnel.Response[i:end])
+	}
+
+	// return with a TunnelSendResult without result
+	response_bytes := []byte{MessageTypeTunnel}
+	response_bytes = append(response_bytes, tunnel.SessionId...)
+	response_bytes = append(response_bytes, TunnelSendResult...)
+
+	response_message, err_responsemessage := NewTunnelMessage(response_bytes)
+	if err_responsemessage != nil {
+		return nil, err_responsemessage
+	}
+
+	return response_message, nil
+}
+
+/*
+in:
+
+	TunnelReceive
+	02 0000000d 00000001 00000000
+
+out:
+
+	TunnelReceiveResult
+	02 0000000d 00000002 485454502f312e3120323030204f4b0d0a436f6e74656e742d547970653a206170706c69636174696f6e2f6a6176617363726970740d0a…
+*/
+func (tunnel *SysclientTunnel) HandleTunnelReceive(message *TunnelMessage) (*TunnelMessage, error) {
+
+	response_bytes := []byte{MessageTypeTunnel}
+	response_bytes = append(response_bytes, tunnel.SessionId...)
+	if len(tunnel.ResponseChunks) > 0 {
+		// return with a TunnelReceiveResult
+		data := tunnel.ResponseChunks[0]
+		tunnel.ResponseChunks = tunnel.ResponseChunks[1:]
+
+		if len(tunnel.ResponseChunks) > 0 {
+			// the are more chunks
+			response_bytes = append(response_bytes, []byte{0x00, 0x00, 0x00, 0x02}...)
+		} else {
+			// this is the last chunk
+			response_bytes = append(response_bytes, []byte{0x00, 0x00, 0x00, 0x02}...)
+
+		}
+		response_bytes = append(response_bytes, data...)
+	} else {
+		// return with a TunnelShutdown
+		return nil, errors.New("no chunks left to send")
+	}
+
+	response_message, err_responsemessage := NewTunnelMessage(response_bytes)
+	if err_responsemessage != nil {
+		return nil, err_responsemessage
+	}
+
+	return response_message, nil
+}
+
+// Define a HttpResponseWriter ResponseWriter
+type HttpResponseWriter struct {
+	response string
+	status   int
+	header   http.Header
+}
+
+func (w *HttpResponseWriter) Write(p []byte) (int, error) {
+	w.response += string(p)
+	return len(w.response), nil
+}
+
+func (w *HttpResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+
+func (w *HttpResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+func (w *HttpResponseWriter) GetBytes() []byte {
+	bu := fmt.Sprintf("HTTP/1.1 %v\r\n", http.StatusText(w.status))
+	bu += fmt.Sprintf("%s: %s\r\n", "Content-Length", strconv.Itoa(len(w.response)))
+	bu += fmt.Sprintf("%s: %s\r\n", "Content-Type", http.DetectContentType([]byte(w.response)))
+	bu += "\r\n"
+	bu += w.response
+	return []byte(bu)
+}

--- a/sysclient/tunnel_test.go
+++ b/sysclient/tunnel_test.go
@@ -1,0 +1,196 @@
+package sysclient_test
+
+import (
+	"testing"
+
+	"github.com/ricoschulte/go-myapps/sysclient"
+	"gotest.tools/assert"
+)
+
+func TestTunnelMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+
+		Type           byte
+		SessionId      []byte
+		SessionIdInt32 int32
+		EventType      []byte
+		Data           []byte
+
+		Error     bool
+		ErrorText string
+	}{
+		{
+			name: "Dummy",
+			raw:  []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0xff},
+
+			Type:           0x02,
+			SessionId:      []byte{0x00, 0x00, 0x00, 0x00},
+			SessionIdInt32: 0,
+			EventType:      []byte{0x00, 0x00, 0x00, 0x00},
+			Data:           []byte{0xff, 0x00, 0xff},
+
+			Error:     false,
+			ErrorText: "",
+		},
+		{
+			name: "b",
+			raw:  []byte{0x02, 0x12, 0x34, 0x56, 0x78, 0xa1, 0xa2, 0xa3, 0xa4, 0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0x12, 0x34, 0x56, 0x78},
+			SessionIdInt32: 305419896,
+			EventType:      []byte{0xa1, 0xa2, 0xa3, 0xa4},
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "TunnelSend",
+			raw: []byte{0x02, 0x12, 0x34, 0x56, 0x78,
+				0x00, 0x00, 0x00, 0x00,
+				0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0x12, 0x34, 0x56, 0x78},
+			SessionIdInt32: 305419896,
+			EventType:      sysclient.TunnelSend,
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+
+			name: "TunnelReceive",
+			raw: []byte{0x02, 0x12, 0x34, 0x56, 0x78,
+				0x00, 0x00, 0x00, 0x01,
+				0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0x12, 0x34, 0x56, 0x78},
+			SessionIdInt32: 305419896,
+			EventType:      sysclient.TunnelReceive,
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "TunnelReceiveResult",
+			raw: []byte{0x02,
+				0x12, 0x34, 0x56, 0x78,
+				0x00, 0x00, 0x00, 0x02,
+				0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0x12, 0x34, 0x56, 0x78},
+			SessionIdInt32: 305419896,
+			EventType:      sysclient.TunnelReceiveResult,
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "TunnelSendResult",
+			raw: []byte{0x02, 0x12, 0x34, 0x56, 0x78,
+				0x00, 0x00, 0x00, 0x03,
+				0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0x12, 0x34, 0x56, 0x78},
+			SessionIdInt32: 305419896,
+			EventType:      sysclient.TunnelSendResult,
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "TunnelShutdown",
+			raw: []byte{0x02, 0xff, 0xff, 0xff, 0xff,
+				0x00, 0x00, 0x00, 0x04,
+				0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0xff, 0xff, 0xff, 0xff},
+			SessionIdInt32: -1,
+			EventType:      sysclient.TunnelShutdown,
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     false,
+			ErrorText: "",
+		}, {
+			name: "Not a Tunnel Message",
+			raw: []byte{0x01, // is a Admin message
+				0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x03, 0xf1, 0xf2, 0xf3},
+
+			Type:           0x02,
+			SessionId:      []byte{0x12, 0x34, 0x56, 0x78},
+			SessionIdInt32: 305419896,
+			EventType:      sysclient.TunnelShutdown,
+			Data:           []byte{0xf1, 0xf2, 0xf3},
+
+			Error:     true,
+			ErrorText: "message is not a TunnelMessage",
+		}, {
+			name: "Message with invalid length",
+			raw:  []byte{0x02, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00 /* , one missing*/},
+
+			Type:           0x00,
+			SessionId:      nil,
+			SessionIdInt32: 0,
+			EventType:      nil,
+			Data:           nil,
+
+			Error:     true,
+			ErrorText: "invalid length of message",
+			// }, {
+			// 	name: "Message requesting Response but has no data",
+			// 	raw:  []byte{0x02, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00 /* , one missing*/},
+
+			// 	Type:      0x00,
+			// 	SessionId: nil,
+			// 	EventType: nil,
+			// 	Data:      nil,
+
+			// 	Error:     true,
+			// 	ErrorText: "invalid length of data",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m, err := sysclient.NewTunnelMessage(test.raw)
+			if test.Error {
+				// error expected
+				if err == nil {
+					t.Fatal("returned no error")
+				}
+				assert.Equal(t, test.ErrorText, err.Error(), "invalid ErrorText")
+			} else {
+				// no error expected
+				if err != nil {
+					t.Fatalf("returned error: %v", err)
+				}
+
+				assert.Equal(t, test.Type, m.Type)
+
+				assert.Equal(t, 4, len(m.SessionId), "SessionId has invalid length")
+				assert.DeepEqual(t, test.SessionId, m.SessionId)
+
+				IdInt32, err_session_int32 := m.GetSessionId()
+				assert.NilError(t, err_session_int32, "returned a error while returning SessionId as in64")
+				assert.Equal(t, test.SessionIdInt32, IdInt32, "invalid int32 SessionId")
+
+				assert.Equal(t, 4, len(m.EventType), "EventType has invalid length")
+				assert.DeepEqual(t, test.EventType, m.EventType)
+
+				assert.Equal(t, len(test.Data), len(m.Data), "Data has invalid length")
+				assert.DeepEqual(t, test.Data, m.Data)
+
+				assert.DeepEqual(t, test.raw, m.AsBytes())
+			}
+
+		})
+	}
+
+}


### PR DESCRIPTION
An implementation of the Sysclient protocol described at [Sysclient protocol](https://sdk.innovaphone.com/13r3/doc/protocol/sysclient.htm)

- connects a Go client to the innovaphone Devices App as a sysclient like any other device.
- can be used to provide a web interface with text or other functions.
- or to record or check the configurations devices receive from the Devices app.
- useful during the development of myApps apps when they have to have access to devices. Allows to use mock/dummy devices instead of having to maintain real ones.

Closes #1 